### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This is a collection of Google-native tools (e.g., Gmail, Calendar) for the [MCP protocol](https://modelcontextprotocol.com/docs/mcp-protocol), designed to integrate seamlessly with AI clients like Claude or Cursor.
 
+<a href="https://glama.ai/mcp/servers/@vakharwalad23/google-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@vakharwalad23/google-mcp/badge" alt="Google MCP server" />
+</a>
+
 <details>
 <summary>JSON configs</summary>
 


### PR DESCRIPTION
This PR adds a badge for the [Google MCP](https://glama.ai/mcp/servers/@vakharwalad23/google-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@vakharwalad23/google-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@vakharwalad23/google-mcp/badge" alt="Google MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.